### PR TITLE
Add recording hotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ You can run the app like any other desktop app on your computer. If you decided 
 ### Recording
 
 From the app tray or GUI, you can start and stop a recording as well as pause and resume a recording. Pausing and resuming is important for when you want to hide sensitive information like credit card of login credentials. You can optionally name your recording and give it a description upon stopping a recording. You can also view your recordings by pressing the "Show Recordings" option.
+You can also press `ctrl`+`alt`+`r` to quickly start or stop a recording.
 
 ### Playback
 

--- a/ducktrack/app.py
+++ b/ducktrack/app.py
@@ -13,6 +13,7 @@ from .obs_client import close_obs, is_obs_running, open_obs
 from .playback import Player, get_latest_recording
 from .recorder import Recorder
 from .util import get_recordings_dir, open_file
+from .keycomb import KeyCombinationListener
 
 
 class TitleDescriptionDialog(QDialog):
@@ -52,9 +53,14 @@ class MainInterface(QWidget):
         
         self.init_tray()
         self.init_window()
-        
+
         if not is_obs_running():
             self.obs_process = open_obs()
+
+        # listen for global hotkey to toggle recording
+        self.hotkey_listener = KeyCombinationListener()
+        self.hotkey_listener.add_comb(("ctrl", "alt", "r"), self.toggle_record)
+        self.hotkey_listener.start()
 
     def init_window(self):
         self.setWindowTitle("DuckTrack")
@@ -170,6 +176,8 @@ class MainInterface(QWidget):
             self.toggle_record()
         if hasattr(self, "obs_process"):
             close_obs(self.obs_process)
+        if hasattr(self, "hotkey_listener"):
+            self.hotkey_listener.stop()
         self.app.quit()
 
     def closeEvent(self, event):


### PR DESCRIPTION
## Summary
- allow ctrl+alt+r to toggle recording
- document shortcut in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b016273883239e7c092f7f5ab457